### PR TITLE
added a suppressWarnings to get rid of apparently meaningless warning

### DIFF
--- a/R/trait_fit_distributions.R
+++ b/R/trait_fit_distributions.R
@@ -127,10 +127,10 @@ trait_fit_distributions <- function(filled_traits,
       distribution_type[.data[[trait_col]]]
     )) |>
     summarize(
-      quiet(get_dist_parms(
+      suppressWarnings(quiet(get_dist_parms(
         data = .data[[value_col]],
         distribution_type = unique(distribution_type)
-      )),
+      ))),
       .groups = "keep"
     )
 

--- a/R/trait_fit_distributions.R
+++ b/R/trait_fit_distributions.R
@@ -44,6 +44,7 @@
 #' @export
 trait_fit_distributions <- function(filled_traits,
                                     distribution_type = "normal") {
+  
   # Check filled traits
   if (!inherits(filled_traits, "filled_trait")) {
     stop("filled traits are not appropriately formatted.
@@ -129,7 +130,7 @@ trait_fit_distributions <- function(filled_traits,
     summarize(
       suppressWarnings(quiet(get_dist_parms(
         data = .data[[value_col]],
-        distribution_type = unique(distribution_type)
+        distribution_type = unique(.data$distribution_type)
       ))),
       .groups = "keep"
     )


### PR DESCRIPTION
For some reason fitting distributions using summarize() is throwing errors, but not when running in a for() loop.  The output of the two approaches is identical.  Since this seems to be a trivial warning, I'm just dealing with it via a SuppressWarnings() call.

After this minor change, the function works as expected.